### PR TITLE
fix: 클럽 리뷰 clubId 바뀔때마다 새로운 쿼리 가져오기(queryKey에 clubId 포함)

### DIFF
--- a/src/components/review/ClubReviewCard.tsx
+++ b/src/components/review/ClubReviewCard.tsx
@@ -9,11 +9,7 @@ import LikeButton from '../common/LikeButton/LikeButton';
 import { useInView } from 'react-intersection-observer';
 import ReviewPageSkeleton from './ReviewPageSkeleton';
 
-interface ReviewCardProps {
-  clubId: string;
-}
-
-function ClubReviewCard({ clubId }: ReviewCardProps) {
+function ClubReviewCard({ clubId }: { clubId: string }) {
   const navigate = useNavigate();
 
   const pageSize = 10;

--- a/src/components/review/ClubReviewList.tsx
+++ b/src/components/review/ClubReviewList.tsx
@@ -26,10 +26,7 @@ function ClubReviewList() {
               src={club.clubImage}
               css={{ cursor: 'pointer' }}
               selected={club.clubId === selectedClubId}
-              onClick={() => {
-                console.log(`클릭된 clubId: ${club.clubId}`);
-                setSelectedClubId(club.clubId);
-              }}
+              onClick={() => setSelectedClubId(club.clubId)}
             />
           </ClubItem>
         ))}

--- a/src/components/review/ClubReviewList.tsx
+++ b/src/components/review/ClubReviewList.tsx
@@ -7,10 +7,8 @@ import ClubReviewCard from './ClubReviewCard';
 function ClubReviewList() {
   const { joinData } = useJoinClubReviewsQuery();
 
-  // 현재 선택된 클럽의 ID 상태
   const [selectedClubId, setSelectedClubId] = useState<string | null>(null);
 
-  // joinData가 로드되면 첫 번째 클럽의 ID로 설정
   useEffect(() => {
     if (joinData?.data?.clubs && joinData.data.clubs.length > 0) {
       setSelectedClubId(joinData.data.clubs[0].clubId);
@@ -20,26 +18,24 @@ function ClubReviewList() {
   return (
     <>
       <ClubContainer>
-        {joinData &&
-          joinData.data.clubs.map((club) => {
-            return (
-              <ClubItem key={club.clubId}>
-                <Avatar
-                  size="medium"
-                  username={club.clubName}
-                  src={club.clubImage}
-                  css={{ cursor: 'pointer' }}
-                  selected={club.clubId === selectedClubId}
-                  onClick={() => setSelectedClubId(club.clubId)}
-                />
-              </ClubItem>
-            );
-          })}
+        {joinData?.data.clubs.map((club) => (
+          <ClubItem key={club.clubId}>
+            <Avatar
+              size="medium"
+              username={club.clubName}
+              src={club.clubImage}
+              css={{ cursor: 'pointer' }}
+              selected={club.clubId === selectedClubId}
+              onClick={() => {
+                console.log(`클릭된 clubId: ${club.clubId}`);
+                setSelectedClubId(club.clubId);
+              }}
+            />
+          </ClubItem>
+        ))}
       </ClubContainer>
 
-      <ClubReviewListContainer>
-        {joinData && joinData.data.clubs.length > 0 && selectedClubId ? <ClubReviewCard clubId={selectedClubId!} /> : <ClubReviewCard.Empty />}
-      </ClubReviewListContainer>
+      <ClubReviewListContainer>{selectedClubId ? <ClubReviewCard clubId={selectedClubId} /> : <ClubReviewCard.Empty />}</ClubReviewListContainer>
     </>
   );
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,7 +1,7 @@
 export const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 export const END_POINTS = {
-  CLUB_JOIN: '/api/clubs/reviews',
+  CLUB_JOIN: '/api/clubs/reviews/my',
   CLUBS: '/api/clubs',
   MY_CLUBS: '/api/clubs/myclub',
   TOKEN: `/api/auth/reissue`,

--- a/src/hooks/queries/useReviewsQuery.ts
+++ b/src/hooks/queries/useReviewsQuery.ts
@@ -82,10 +82,9 @@ export const useClubReviewsQuery = (clubId: string) => {
     fetchNextPage,
     isFetchingNextPage
   } = useInfiniteQuery<ReviewsResponse, Error>({
-    queryKey: ['clubReviews'],
+    queryKey: ['clubReviews', clubId],
     queryFn: async ({ pageParam = 0 }) => {
       const response = await getClubReviews(clubId, pageParam);
-      
       // 응답 데이터 검증
       if (!response || !response.data || !response.data.reviews) {
         throw new Error('Invalid API response structure');


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

POV-187-club-detail -> dev

### 변경 사항
기존에 선택된 club에 띠라 데이터가 업데이트 되지 않은 문제를 해결했습니다.

useInfiniteQuery의 queryKey에 clubId를 포함하여 clubId가 변경될 때마다 새로운 쿼리로 데이터를 새로 가져오도록 수정했습니다.

### 테스트 결과
<img width="914" alt="image" src="https://github.com/user-attachments/assets/88960ab5-b39e-4b4d-9b3c-25cc16475076" />
<img width="897" alt="image" src="https://github.com/user-attachments/assets/c78f8f57-7c78-4a11-82d1-48446838aa5f" />
