### PR TITLE
fix: interceptor header 변경

### DIFF
--- a/src/apis/auth/postAuth.ts
+++ b/src/apis/auth/postAuth.ts
@@ -40,8 +40,10 @@ export const postLogin = async (email: string, socialType: string) => {
 
     // Access Token을 Session Storage에 저장
     const headers = response.headers;
-    const accessToken = headers['Authorization'];
+    const accessToken = headers['authorization'];
+
     console.log('accessToken =', accessToken);
+
     if (accessToken) {
       localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
     }

--- a/src/apis/intersceptors.ts
+++ b/src/apis/intersceptors.ts
@@ -12,7 +12,7 @@ export interface ErrorResponseData {
 export const checkSetToken = (config: InternalAxiosRequestConfig) => {
   if (!config.headers || config.headers.Authorization) return config;
 
-  const accessToken = sessionStorage.getItem(ACCESS_TOKEN_KEY);
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
   config.headers.Authorization = `${accessToken}`;
 
   return config;

--- a/src/pages/Oauth/Google/Index.tsx
+++ b/src/pages/Oauth/Google/Index.tsx
@@ -2,8 +2,8 @@ import { useEffect } from 'react';
 import Padded from '../../../components/templates/Padded/Padded';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { getGoogleUserInfoApi } from '../../../apis/auth/oauthApi';
-import { postLoginApi } from '../../../apis/auth/loginApi';
 import { useAuthStore } from '../../../stores/useAuthStore';
+import { postLogin } from '../../../apis/auth/postAuth';
 
 const Index = () => {
   const navigate = useNavigate();
@@ -24,13 +24,13 @@ const Index = () => {
 
         if (data) {
           try {
-            const response = await postLoginApi(data.email, 'GOOGLE');
+            const response = await postLogin(data.email, 'GOOGLE');
 
             if (response.data.exists) {
               setLoggedIn(true);
               setUser(response.data.memberInfo);
               alert('로그인 성공');
-              navigate('/main');
+              window.location.href = '/';
             } else {
               alert('최초 로그인, 회원가입으로 이동');
               navigate('/signup', {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 배포 

### 반영 브랜치

hotfix-02 -> main

### 변경 사항

> - axios intercepor의 header에 들어가는 access token을 local storage에서 읽어오도록 수정했습니다.
> - Google 로그인 시 access token을 session storage에 저장하지 않고 local storage에 저장하도록 변경했습니다.
> - Google 로그인, Naver 로그인 POST API를 하나의 메소드로 통일했습니다.