### PR TITLE
Pov lazy suspense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5041,6 +5041,7 @@
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
       "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
       }

--- a/src/components/movies/Card/Card.styles.ts
+++ b/src/components/movies/Card/Card.styles.ts
@@ -69,7 +69,7 @@ export const Info = styled.div`
 export const Count = styled.span``;
 
 export const MarginTop = styled.div`
-  margin-top: 60px;
+  margin-top: 37px;
 `;
 
 export const LikeContainer = styled.div`

--- a/src/components/movies/Section/Section.styles.ts
+++ b/src/components/movies/Section/Section.styles.ts
@@ -7,7 +7,6 @@ export const SectionContainer = styled.section`
   width: 100%;
 
   margin-top: 24px;
-  margin-bottom: 48px;
 
   &:last-child {
     margin-bottom: 0;

--- a/src/components/review/ReviewPageSkeleton.tsx
+++ b/src/components/review/ReviewPageSkeleton.tsx
@@ -13,6 +13,7 @@ const ReviewPageSkeleton = () => {
             <ReviewCardContainer>
               <Skeleton width="100%" />
               <Skeleton width="100%" height="100px" />
+              <Skeleton width="100%" />
             </ReviewCardContainer>
           </CardFlex>
         </CardContainer>

--- a/src/pages/Main/MainPageSkeleton.tsx
+++ b/src/pages/Main/MainPageSkeleton.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from 'pov-design-system';
-import { SectionContainer, CardContainer } from '../../components/movies/Section/Section.styles';
+import { SectionContainer } from '../../components/movies/Section/Section.styles';
 import { MarginTop } from '../../components/movies/Card/Card.styles';
 import MoviePageSkeleton from '../Movie/MoviePageSkeleton';
 import { PopularReviewListContainer } from '../../components/review/ReviewCard.style';
@@ -10,9 +10,7 @@ const MainPageSkeleton = () => {
     <MarginTop>
       <SectionContainer>
         <Skeleton width="100%" height="30px" />
-        <CardContainer>
-          <MoviePageSkeleton />
-        </CardContainer>
+        <MoviePageSkeleton />
       </SectionContainer>
 
       <Skeleton width="100%" height="30px" />

--- a/src/pages/Main/MainPageSkeleton.tsx
+++ b/src/pages/Main/MainPageSkeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from 'pov-design-system';
+import { SectionContainer, CardContainer } from '../../components/movies/Section/Section.styles';
+import { MarginTop } from '../../components/movies/Card/Card.styles';
+import MoviePageSkeleton from '../Movie/MoviePageSkeleton';
+
+const MainPageSkeleton = () => {
+  return (
+    <MarginTop>
+      <SectionContainer>
+        <Skeleton width="100%" height="30px" />
+        <CardContainer>
+          <MoviePageSkeleton />
+        </CardContainer>
+      </SectionContainer>
+    </MarginTop>
+  );
+};
+
+export default MainPageSkeleton;

--- a/src/pages/Main/MainPageSkeleton.tsx
+++ b/src/pages/Main/MainPageSkeleton.tsx
@@ -2,6 +2,8 @@ import { Skeleton } from 'pov-design-system';
 import { SectionContainer, CardContainer } from '../../components/movies/Section/Section.styles';
 import { MarginTop } from '../../components/movies/Card/Card.styles';
 import MoviePageSkeleton from '../Movie/MoviePageSkeleton';
+import { PopularReviewListContainer } from '../../components/review/ReviewCard.style';
+import ReviewPageSkeleton from '../../components/review/ReviewPageSkeleton';
 
 const MainPageSkeleton = () => {
   return (
@@ -12,6 +14,13 @@ const MainPageSkeleton = () => {
           <MoviePageSkeleton />
         </CardContainer>
       </SectionContainer>
+
+      <Skeleton width="100%" height="30px" />
+      <PopularReviewListContainer>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <ReviewPageSkeleton key={`initial-skeleton-${index}`} />
+        ))}
+      </PopularReviewListContainer>
     </MarginTop>
   );
 };

--- a/src/pages/Movie/MoviePageSkeleton.tsx
+++ b/src/pages/Movie/MoviePageSkeleton.tsx
@@ -1,26 +1,22 @@
 import { Skeleton } from 'pov-design-system';
-import { SectionContainer, CardContainer } from '../../components/movies/Section/Section.styles';
-import { CardWapper, MarginTop } from '../../components/movies/Card/Card.styles';
+import { CardContainer } from '../../components/movies/Section/Section.styles';
+import { CardWapper } from '../../components/movies/Card/Card.styles';
 import useWindowSize from '../../hooks/utils/useWindowSize';
 
 const MoviePageSkeleton = () => {
   const windowSize = useWindowSize();
 
   return (
-    <MarginTop>
-      <SectionContainer>
-        <CardContainer>
-          {Array.from({ length: 6 }).map((_, index) => (
-            <CardWapper key={`skeleton-${index}`}>
-              <Skeleton width={windowSize.width! > 600 ? '169px' : '169px'} height={windowSize.width! > 600 ? '282px' : '282px'} />
-              <Skeleton width={windowSize.width! > 600 ? '100px' : '169px'} height="20px" />
-              <Skeleton width={windowSize.width! > 600 ? '40px' : '169px'} height="16px" />
-              <Skeleton width={windowSize.width! > 600 ? '60px' : '169px'} height="20px" />
-            </CardWapper>
-          ))}
-        </CardContainer>
-      </SectionContainer>
-    </MarginTop>
+    <CardContainer>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <CardWapper key={`skeleton-${index}`}>
+          <Skeleton width={windowSize.width! > 600 ? '169px' : '169px'} height={windowSize.width! > 600 ? '282px' : '282px'} />
+          <Skeleton width={windowSize.width! > 600 ? '100px' : '169px'} height="20px" />
+          <Skeleton width={windowSize.width! > 600 ? '40px' : '169px'} height="16px" />
+          <Skeleton width={windowSize.width! > 600 ? '60px' : '169px'} height="20px" />
+        </CardWapper>
+      ))}
+    </CardContainer>
   );
 };
 

--- a/src/pages/Movie/index.tsx
+++ b/src/pages/Movie/index.tsx
@@ -6,6 +6,8 @@ import { useMoviesQuery } from '../../hooks/queries/useMoviesQuery';
 import { useInView } from 'react-intersection-observer';
 import { useEffect } from 'react';
 import MoviePageSkeleton from './MoviePageSkeleton';
+import { Skeleton } from 'pov-design-system';
+import { SectionContainer } from '../../components/movies/Section/Section.styles';
 
 const Index = () => {
   const user = useAuthStore((state) => state.user);
@@ -26,9 +28,12 @@ const Index = () => {
     // 초기 로딩 시 스켈레톤 12개 렌더링
     return (
       <>
-        {Array.from({ length: pageSize }).map((_, index) => (
-          <MoviePageSkeleton key={`initial-skeleton-${index}`} />
-        ))}
+        <SectionContainer>
+          <Skeleton width="100%" height="30px" />
+          {Array.from({ length: pageSize }).map((_, index) => (
+            <MoviePageSkeleton key={`initial-skeleton-${index}`} />
+          ))}
+        </SectionContainer>
       </>
     );
   }

--- a/src/routes/RouteDef.tsx
+++ b/src/routes/RouteDef.tsx
@@ -1,5 +1,5 @@
 import Main from '../pages/Main';
-import Movie from '../pages/Movie';
+import Movie from '../pages/Movie/Index';
 import MovieTrending from '../pages/Movie/MovieTrending/Index';
 import MovieSearch from '../pages/Movie/MovieSearch/Index';
 import MovieDetail from '../pages/Movie/MovieDetail/Index';
@@ -33,8 +33,6 @@ import MyPage from '../pages/MyPage';
 import Settings from '../pages/MyPage/Settings';
 import NotFound from '../pages/NotFound/Index';
 
-// import React, { lazy, Suspense } from 'react';
-
 // Admin
 import AdminMovie from '../admins/Movie/Index';
 import AdminMovieDetail from '../admins/Movie/MovieDetail/Index';
@@ -47,11 +45,19 @@ import AdminCurationsDetail from '../admins/Movie/curationDetail/Index';
 import AdminCurationUpdate from '../admins/Movie/curationUpdate/Index';
 import AdminReviews from '../admins/reviews/Index';
 import AdminReviewDetail from '../admins/reviews/reviewDetail/Index';
+import MainPageSkeleton from '../pages/Main/MainPageSkeleton';
+
+import { Suspense } from 'react';
+import * as Lazy from './lazy';
 
 const MovieScreens = {
   Main: {
     path: '/',
-    element: <Main />,
+    element: (
+      <Suspense fallback={<MainPageSkeleton />}>
+        <Lazy.MainPage />
+      </Suspense>
+    ),
   },
   Movies: {
     path: '/movie',

--- a/src/routes/RouteDef.tsx
+++ b/src/routes/RouteDef.tsx
@@ -1,4 +1,3 @@
-import Main from '../pages/Main';
 import Movie from '../pages/Movie/Index';
 import MovieTrending from '../pages/Movie/MovieTrending/Index';
 import MovieSearch from '../pages/Movie/MovieSearch/Index';

--- a/src/routes/lazy.ts
+++ b/src/routes/lazy.ts
@@ -1,0 +1,23 @@
+import { lazy } from 'react';
+
+export const MainPage = lazy(
+  () => import('../pages/Main')
+);
+
+export const MoviePage = lazy(
+  () => import('../pages/Movie/Index')
+);
+
+export const LogInPage = lazy(
+  () => import('../pages/Login/Index')
+);
+
+export const MyPage = lazy(() => import('../pages/MyPage'));
+
+export const ClubPage = lazy(
+  () => import('../pages/Club/')
+);
+
+export const PremieresPage = lazy(
+  () => import('../pages/Premieres')
+);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

POV-lazy-suspense -> dev

### 변경 사항
> Lazy loading으로 code splitting 하기 위해서 일단 먼저 스켈레톤 UI 적용이 안된 메인 페이지부터 적용해보았습니다.

- React 공식 문서에서는 lazy를 React-Router 라이브러리를 사용한 routing 기반 코드 분할을 추천하고 있습니다.
- Lazy loading으로 code splitting을 적용하게 되면 vite와 같은 모듈 번들러를 이용해 만들어진 하나의 번들파일이 여러개로 나뉘며 성능 최적화가 됩니다.

-> 따라서 index.js의 빌드 파일의 용량이 줄어들고, 용량 압축 차이로 SPA 특성의 초기 로딩 시간에 UX 차이를 보입니다. 

> 남은 routing 페이지 단위로 스켈레톤 UI가 적용되지 않은 부분만 lazy loading을 적용 예정입니다.

### 테스트 결과
> 코드 적용
<img width="389" alt="image" src="https://github.com/user-attachments/assets/21dd6cd0-0200-4558-b746-cd9e26f5b37d" />

```
React.lazy로 불러온 컴포넌트는 단독으로 쓰일 수 없고 React.Suspense 컴포넌트 하위에서 렌더링되어야 한다.
```

> 스켈레톤 UI가 적용된 화면
<img width="741" alt="image" src="https://github.com/user-attachments/assets/47abc817-f6b0-4928-9ba3-e6cb5b13a524" />

